### PR TITLE
Set one more explicit version

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ command line in your crate root. Otherwise, add the following to your
 
 ```toml
 [dev-dependencies]
-quickcheck = "*"
+quickcheck = "0.4"
 ```
 
 Now you can use quickcheck in your tests! The easiest way is:


### PR DESCRIPTION
You know the drill: People should never see nor copy dependencies with `*` as a
version. Ever.

Just imagine a newbie, who sees this in a prestigious repository like this one!
They might think it's okay. BUT IT IS NOT OKAY. `*` dependencies undermine
everything we have all worked hard on: Cargo, SemVer, non-breaking changes,
getting stuff to compile even when you misplaced your project's `Cargo.lock` and
it's three years later all of the sudden.

(This commit-message-rant was brought to by: Waiting For It To Compile, your
personal distributor of unused time. Visit us at `cd ~/projects`, we are open
every day of the week from `cargo test` until `cargo build --release`.)